### PR TITLE
Fix JSON parsing resilience and test script id serialization

### DIFF
--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -1518,11 +1518,24 @@ if ([string]::IsNullOrEmpty($jsonRequestBody)) {
 
         if ($WebhookData -match '"?RequestBody"?\s*:\s*((?:{([^{}]|(?<open>{)|(?<-open>}))*(?(open)(?!))})|(?:\[([^\[\]]|(?<open>\[)|(?<-open>\]))*(?(open)(?!))\]))') {
             $jsonRequestBody = $matches[1]
+            Write-CertLCLog -Section 'Dispatcher' -Message "Regex extracted RequestBody: $jsonRequestBody"
             try {
                 $RequestBody = ConvertFrom-Json -InputObject $jsonRequestBody -Depth 10
             }
             catch {
-                Write-CertLCLogAndThrow -Section 'Dispatcher' -Message 'Failed to parse WebhookData.RequestBody using regex' -Inner $_.Exception
+                # The extracted body may contain literal escape sequences (e.g. \r\n, \") from callers that
+                # double-serialized the JSON (sent an already-escaped string as the HTTP body).
+                # Try unescaping those sequences and parsing again before giving up.
+                Write-CertLCLog -Level Warning -Section 'Dispatcher' -Message "First parse attempt failed: $($_.Exception.Message). Attempting to unescape literal \r\n and \`" sequences and retry..."
+                $jsonRequestBody = $jsonRequestBody -replace '\\r\\n', "`r`n" -replace '\\"', '"'
+                Write-CertLCLog -Section 'Dispatcher' -Message "Unescaped RequestBody: $jsonRequestBody"
+                try {
+                    $RequestBody = ConvertFrom-Json -InputObject $jsonRequestBody -Depth 10
+                    Write-CertLCLog -Section 'Dispatcher' -Message 'Successfully parsed RequestBody after unescaping.'
+                }
+                catch {
+                    Write-CertLCLogAndThrow -Section 'Dispatcher' -Message 'Failed to parse WebhookData.RequestBody using regex (even after unescaping)' -Inner $_.Exception
+                }
             }
         }
         else { Write-CertLCLogAndThrow -Section 'Dispatcher' -Message 'WebhookData.RequestBody not recognized using regex!' }
@@ -1562,6 +1575,13 @@ if ([string]::IsNullOrEmpty($requestBody.type)) {
 }
 else {
     Write-CertLCLog -Section 'Dispatcher' -Message "request type: $($requestBody.type)"
+}
+
+if ([string]::IsNullOrEmpty($requestBody.id)) {
+    Write-CertLCLog -Section 'Dispatcher' -Message "request id: (not provided)" -Level 'Warning'
+}
+else {
+    Write-CertLCLog -Section 'Dispatcher' -Message "request id: $($requestBody.id)"
 }
 
 # Process requests based on type

--- a/Utilities/testnewcert.ps1
+++ b/Utilities/testnewcert.ps1
@@ -131,7 +131,7 @@ For new certificate requests, the body has a structure like this:
 #>
 
 $data = [ordered]@{
-  id          = (New-Guid)
+  id          = (New-Guid).ToString()
   source      = 'testnewcert.ps1'
   specversion = '1.0'
   type        = 'CertLC.NewCertificateRequest'

--- a/Utilities/testrevocationcert.ps1
+++ b/Utilities/testrevocationcert.ps1
@@ -101,7 +101,7 @@ For certificate revocation requests, the body has a structure like this:
 #>
 
 $data = [ordered]@{
-  id          = (New-Guid)
+  id          = (New-Guid).ToString()
   source      = 'testrevocationcert.ps1'
   specversion = '1.0'
   type        = 'CertLC.CertificateRevocationRequest'


### PR DESCRIPTION
## Changes

- **Test scripts** (`testnewcert.ps1`, `testrevocationcert.ps1`): Fix `New-Guid` serialization — use `.ToString()` so the `id` field is a plain string, not a Guid object that serializes as `{"value":"...","Guid":"..."}`

- **certlc.ps1 Dispatcher**:
  - Add request `id` logging after request type validation
  - Add unescape fallback in the regex parsing path: when the initial `ConvertFrom-Json` fails on the regex-extracted body, unescape literal `\r\n` and `\"` sequences and retry. This handles callers (e.g. ServiceNow) that double-serialize their JSON body.
  - Add detailed logging at each parsing step for troubleshooting

## Context

ServiceNow webhook calls were failing because the HTTP body contained literal `\r\n` and `\"` escape sequences (double-serialized JSON). The runbook parser now gracefully handles this case while remaining backward compatible with correctly formatted callers.