### PR TITLE
Fix Azure CLI default package key in runtime environment

### DIFF
--- a/Setup/certlc.bicep
+++ b/Setup/certlc.bicep
@@ -472,7 +472,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2024-10-23' 
       }
       defaultPackages: {
         Az: '15.1.0'
-        AzureCLI: '2.77.0'
+        'Azure CLI': '2.77.0'
       }
     }
     tags: commonTags


### PR DESCRIPTION
## Summary

Fix the default-package key name in the custom PowerShell 7.6 runtime environment introduced in #39 / release 3.4.0.

## Problem

Deployment of `Setup/certlc.bicep` failed with:

```
BadRequest: AzureCLI is not a supported default package.
Supported packages are - Az, Azure CLI.
```

The runtime environment was declared with the key `AzureCLI` (no space), but the Automation API expects `Azure CLI` (with a space).

## Fix

Use the bicep quoted-property-name syntax to set the key correctly:

```bicep
defaultPackages: {
  Az: '15.1.0'
  'Azure CLI': '2.77.0'
}
```

## Validation

- `az bicep build` — compiles cleanly.
- `az deployment group create` against `rg-certlc-itn-001` — **Succeeded** in ~54s.
- Verified via ARM REST: runtime environment `certlc-PowerShell-7-6` now lists default packages `Az=15.1.0, Azure CLI=2.77.0`. Both runbooks (`certlc`, `certlcstats`) are bound to the new environment.