### PR TITLE
Code-review backlog: security, robustness, cosmetics, and docs refresh

### DIFF
--- a/LogAnalytics/customTable/README.md
+++ b/LogAnalytics/customTable/README.md
@@ -1,12 +1,45 @@
-# Preparation of custom table for certLC statistics
+# Custom Log Analytics table for CertLC statistics
 
-1. create a new DCE in the same region as the Log Analytics workspace
-2. fetch its ingestion URL
-3. in LogAnalytics, create a new custom table, DCR-based, called **certlc**. Do not append _CL (it will be done automatically). When asked, create a DCR for the table in the same region
-4. import the schema from the file `certlcstats-schema.json`
-5. apply the transfromation from the file `certlcstats.transformation`
-6. fetch the **immutableId** fomr the DCR (`dcr-<string>`)
-7. fetch the name of the stream (`Custom-certlc_CL`) from the DCR. Note: it is case sensitive!
-8. on the DCR, assign the role of `Monitoring Metrics Publisher` to the identity of the Automation Account
-9. use stream name, immmutable id, ingestion url, keyvault name as parameters for the `certlcstats.ps1` runbook
+This folder contains the **schema** and the **KQL transformation** applied to the custom Log Analytics table `certlc_CL`, which receives certificate inventory data published by the `certlcstats.ps1` runbook.
 
+> **All resources described here are provisioned automatically by the Bicep template in [`Setup/certlc.bicep`](../../Setup/certlc.bicep).** The files in this folder are kept for reference and to make the schema/transformation auditable in source control. There is no manual portal procedure to follow.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `certstats-schema.json` | Column definitions of the `certlc_CL` table (consumed by the Bicep template) |
+| `certlcstats.transformation` | KQL transformation applied by the Data Collection Rule to incoming records (parses string dates and sets `TimeGenerated`) |
+
+## What the Bicep deployment creates
+
+- **Custom table** `certlc_CL` (the `_CL` suffix is implicit) in the Log Analytics workspace, with the schema in `certstats-schema.json`
+- **Data Collection Endpoint** (DCE) for log ingestion
+- **Data Collection Rule** (DCR) with:
+  - Stream declaration `Custom-certlc_CL` *(case-sensitive)*
+  - The transformation from `certlcstats.transformation`
+  - Destination: the custom table in the Log Analytics workspace
+- **Role assignment** `Monitoring Metrics Publisher` on the DCR for the Automation Account's managed identity
+- **Automation variables** read by `certlcstats.ps1`:
+  - `certlc-stats-keyvault` &mdash; vault to enumerate
+  - `certlc-stats-ingestionurl` &mdash; DCE ingestion endpoint
+  - `certlc-stats-immutableid` &mdash; DCR immutable ID
+  - `certlc-stats-streamname` &mdash; `Custom-certlc_CL`
+
+## Schema
+
+The table has 8 columns (see `certstats-schema.json` for the authoritative definition): `TimeGenerated`, `Thumbprint`, `Name`, `Created`, `Expires`, `Subject`, `Template`, `DNSNames`.
+
+## Querying the data
+
+```kusto
+certlc_CL
+| order by TimeGenerated desc
+| project TimeGenerated, Name, Thumbprint, Subject, Template, Expires
+```
+
+The Azure Monitor workbook in [`Workbooks/certlc.workbook`](../../Workbooks/certlc.workbook) consumes this table to render the certificate inventory dashboard.
+
+## Modifying schema or transformation
+
+Edit the JSON / KQL files in this folder, then redeploy `Setup/certlc.bicep`. Do **not** edit the table or DCR directly in the portal &mdash; the next Bicep deployment will overwrite portal changes.

--- a/README.md
+++ b/README.md
@@ -70,23 +70,29 @@ CertLC provides end-to-end automation for managing certificates stored in Azure 
 1. Azure Key Vault raises a `CertificateNearExpiry` event when a certificate approaches expiration
 2. Event Grid captures the event and delivers it to the Storage Queue
 3. The Function App triggers the renewal process through the Automation runbook
-4. The Hybrid Worker requests a renewed certificate from the Enterprise CA
+4. The Hybrid Worker requests a renewed certificate from the Enterprise CA. The new version is tagged with `RenewedJobId=<automation-job-id>` for traceability back to the renewal job
 5. The renewed certificate replaces the expiring one in Key Vault
+6. **Revoked-latest short-circuit**: if the latest version of the certificate carries `Revoked=true`, the renewal branch logs a warning and exits without contacting the CA. Auto-renewal resumes only after an operator either issues a new version explicitly or clears the `Revoked` tag
 
 ### Certificate Revocation Flow
 
 1. A revocation request with a certificate thumbprint (any version, current or older) is sent to the Storage Queue
 2. The Function App triggers the `certlc` runbook
-3. The runbook locates the matching Key Vault version by thumbprint, extracts its serial number, and submits a revocation request to the CA for that serial
-4. The matching Key Vault version is set to `enabled = false` and tagged with audit metadata (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). **No Key Vault objects are deleted by the runbook**; other versions of the same certificate are left untouched, and the certificate object remains in the vault for audit
-5. If the revoked version is the latest version of the certificate, subsequent `CertificateNearExpiry` events for that certificate are ignored (the renewal branch detects the `Revoked` tag on the latest version and skips auto-renewal)
+3. The runbook locates the matching Key Vault version by thumbprint (LDAP-safe lookup, then a direct REST GET of the version metadata to read its `x5t`)
+4. **Idempotency guard**: if the version already carries `Revoked=true`, the runbook fails fast with an `ALREADY REVOKED` log line that includes the previous `RevokedAt`, `RevocationReason`, and `RevokedJobId`. The CA is not called again and existing tags are preserved
+5. Otherwise, the runbook extracts the version's serial number and submits a revocation request to the CA for that serial
+6. The matching Key Vault version is set to `enabled = false` and tagged with audit metadata (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). Existing tags on the version (e.g. `NotifyTo`, `Hostname`, `PfxProtectTo`) are preserved. **No Key Vault objects are deleted by the runbook**; other versions of the same certificate are left untouched, and the certificate object remains in the vault for audit
 
 ### Statistics Collection
 
-1. The `certlcstats` runbook runs on a schedule (hourly by default)
+1. The `certlcstats` runbook runs on a schedule (hourly by default, disabled until manually linked)
 2. It enumerates all certificates in Key Vault and collects metadata
 3. Certificate data is published to a custom Log Analytics table via Data Collection Rule
 4. Azure Monitor Workbooks can visualize certificate inventory and expiration timelines
+
+### Resilience
+
+Idempotent Key Vault and LDAP reads (certificate-version listing, version metadata GET, AD template discovery) are wrapped in an exponential-backoff retry helper that recovers from transient HTTP 408/429/5xx, `Retry-After` throttling, and common network exceptions. Mutating calls (CA enrollment / revocation, tag writes) are **not** retried automatically — they are surfaced to the operator to avoid duplicate side-effects.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ CertLC provides end-to-end automation for managing certificates stored in Azure 
 
 ### Certificate Revocation Flow
 
-1. A revocation request with the certificate thumbprint is sent to the Storage Queue
+1. A revocation request with a certificate thumbprint (any version, current or older) is sent to the Storage Queue
 2. The Function App triggers the `certlc` runbook
-3. The runbook locates the certificate by thumbprint and submits a revocation request to the CA
-4. The certificate is removed from Key Vault after successful revocation
+3. The runbook locates the matching Key Vault version by thumbprint, extracts its serial number, and submits a revocation request to the CA for that serial
+4. The matching Key Vault version is set to `enabled = false` and tagged with audit metadata (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). **No Key Vault objects are deleted by the runbook**; other versions of the same certificate are left untouched, and the certificate object remains in the vault for audit
+5. If the revoked version is the latest version of the certificate, subsequent `CertificateNearExpiry` events for that certificate are ignored (the renewal branch detects the `Revoked` tag on the latest version and skips auto-renewal)
 
 ### Statistics Collection
 

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -747,7 +747,7 @@ function Export-PfxWithGroupProtection {
     if ($hr) {
         throw 'Export-PfxWithGroupProtection: NCryptCreateProtectionDescriptor failed: 0x{0:X}' -f $hr
     }
-    Write-CertLCLog -Section 'Export-PfxWithGroupProtection' "Protection descriptor handle: $hDesc"
+    Write-CertLCLog -Section 'Export-PfxWithGroupProtection' -Message "Protection descriptor handle: $hDesc"
 
     try {
 
@@ -756,7 +756,7 @@ function Export-PfxWithGroupProtection {
         if ($store -eq [IntPtr]::Zero) {
             throw 'Export-PfxWithGroupProtection: CertOpenStore failed: 0x{0:X}' -f [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         }
-        Write-CertLCLog -Section 'Export-PfxWithGroupProtection' "Memory store handle: $store"
+        Write-CertLCLog -Section 'Export-PfxWithGroupProtection' -Message "Memory store handle: $store"
 
         try {
 
@@ -782,7 +782,7 @@ function Export-PfxWithGroupProtection {
                 if (-not [Win32Native]::PFXExportCertStoreEx($store, [ref]$blob, $password, $pvPara, $flags)) {
                     throw ('Export-PfxWithGroupProtection:: size query failed: 0x{0:X}' -f [Runtime.InteropServices.Marshal]::GetLastWin32Error())
                 }
-                Write-CertLCLog -Section 'Export-PfxWithGroupProtection' "PFX size will be: $($blob.cbData) bytes"
+                Write-CertLCLog -Section 'Export-PfxWithGroupProtection' -Message "PFX size will be: $($blob.cbData) bytes"
 
                 # allocate memory for the PFX data (pass 2)
                 $blob.pbData = [Runtime.InteropServices.Marshal]::AllocHGlobal($blob.cbData)
@@ -800,7 +800,7 @@ function Export-PfxWithGroupProtection {
                     $bytes = New-Object byte[] $blob.cbData
                     [Runtime.InteropServices.Marshal]::Copy($blob.pbData, $bytes, 0, $blob.cbData)
                     [System.IO.File]::WriteAllBytes($PfxFile, $bytes)
-                    Write-CertLCLog -Section 'Export-PfxWithGroupProtection' "PFX exported to file: $PfxFile"
+                    Write-CertLCLog -Section 'Export-PfxWithGroupProtection' -Message "PFX exported to file: $PfxFile"
                 }
                 finally {
                     # free the allocated memory for PFX data
@@ -1660,7 +1660,7 @@ if ([string]::IsNullOrEmpty($jsonRequestBody)) {
         else { Write-CertLCLogAndThrow -Section 'Dispatcher' -Message 'WebhookData.RequestBody not recognized using regex!' }
     }
 
-    if ([string]::IsNullOrEmpty($requestBody)) {
+    if ($null -eq $requestBody) {
         Write-CertLCLogAndThrow -Section 'Dispatcher' -Message 'WebhookData.RequestBody is empty! Ensure the runbook is called from a webhook!'
     }
 }
@@ -1764,7 +1764,7 @@ switch ($requestBody.type) {
         # get NotifyTo from the certificate tags (optional)
         $rawNotifyTo = $cert.Tags['NotifyTo']
         if ([string]::IsNullOrWhiteSpace($rawNotifyTo)) {
-            $notifyTo = null
+            $notifyTo = $null
             Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "No NotifyTo addresses found for certificate $CertificateName in vault $VaultName."
         }
         else {
@@ -1803,7 +1803,7 @@ switch ($requestBody.type) {
 
         # lookup the template name using the OID
         try {
-            Write-CertLCLog -Section 'Dispatcher.Renewal' "Looking up template name for OID: $oid"
+            Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "Looking up template name for OID: $oid"
             $certificateTemplateName = Find-TemplateName -cnOrDisplayNameOrOid $oid
         }
         catch {

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -1274,17 +1274,18 @@ function Get-CertificateByThumbprint {
     }
 
     # Helper: Invoke Key Vault REST API
+    # S1 fix: fetch the access token ONCE at function entry (not per page) and pass it to
+    # Invoke-RestMethod as a SecureString via -Authentication Bearer -Token. PowerShell 7 then
+    # builds the Authorization header internally without ever materializing the token into a
+    # managed (immutable, GC-bound) plaintext String. The previous implementation called
+    # PtrToStringBSTR(SecureStringToBSTR(...)) on every page, both materializing the token and
+    # leaking the BSTR buffer (no ZeroFreeBSTR).
+    $tokenResult = Get-AzAccessToken -ResourceTypeName KeyVault -AsSecureString
+    $secureToken = $tokenResult.Token
     $invokeApi = {
         param([string]$uri)
-        $tokenResult = Get-AzAccessToken -ResourceTypeName KeyVault -AsSecureString
-        $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR(
-            [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResult.Token)
-        )
-        $headers = @{
-            'Authorization' = "Bearer $accessToken"
-            'Content-Type'  = 'application/json'
-        }
-        return Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+        # $secureToken is captured from the enclosing scope
+        return Invoke-RestMethod -Uri $uri -Method GET -Authentication Bearer -Token $secureToken -ContentType 'application/json'
     }
 
     $vaultBaseUrl = "https://$VaultName.vault.azure.net"
@@ -1296,7 +1297,7 @@ function Get-CertificateByThumbprint {
     $uri = "$vaultBaseUrl/certificates?api-version=$apiVersion"
 
     try {
-        :latestLoop do {
+        do {
             $response = & $invokeApi $uri
 
             if ($response.value) {

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -368,6 +368,39 @@ function Send-NotificationEmail {
 
 #endregion
 
+#region ### Send-SuccessNotification ###
+
+#########################################
+# FUNCTIONS - Send-SuccessNotification  #
+#########################################
+
+# Shared success-email helper used by the dispatcher success paths (creation/renewal/revocation).
+# Returns silently if NotifyTo is empty. Logs a warning if NotifyTo is set but SmtpServer is not.
+function Send-SuccessNotification {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Section,
+        [Parameter(Mandatory)][string]$Subject,
+        [Parameter(Mandatory)][string]$BodyText,
+        [Parameter()][string[]]$NotifyTo,
+        [Parameter()][string]$SmtpServer,
+        [Parameter()][string]$FromAddress,
+        [Parameter()][pscredential]$SmtpCredential
+    )
+
+    if (-not $NotifyTo) { return }
+    if ([string]::IsNullOrEmpty($SmtpServer)) {
+        Write-CertLCLog -Section $Section -Level 'Warning' -Message 'Notification requested but SMTP is not configured. Skipping email notification.'
+        return
+    }
+
+    $fragment = [System.Net.WebUtility]::HtmlEncode($BodyText)
+    $body = $CertificateNotificationEmailBodyHtml -replace '__CONTENT__', $fragment
+    Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $FromAddress -To $NotifyTo -Subject $Subject -Body $body -SmtpCredential $SmtpCredential
+}
+
+#endregion
+
 #region ### Write-CertLCLogAndThrow ###
 
 #######################################
@@ -592,16 +625,9 @@ function Convert-PfxProtectToForTag {
         [string[]] $Value
     )
 
-    if (-not $Value -or $Value.Count -eq 0) { return '' }
-
-    # Trim, remove empties, dedupe (case-insensitive), preserve order of first occurrence
-    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    $clean = foreach ($v in $Value) {
-        $t = ($v | ForEach-Object { ($_ ?? '') }) -as [string]
-        $t = $t.Trim()
-        if ($t -and $seen.Add($t)) { $t }
-    }
-    return ($clean -join ';')
+    # Delegate normalization (trim, drop empties, collapse backslashes, dedupe) to Format-PfxProtectTo
+    # to keep both helpers in sync; then join with semicolons for tag storage.
+    return ((Format-PfxProtectTo -InputValue $Value) -join ';')
 }
 
 #endregion
@@ -1412,7 +1438,12 @@ function New-CertificateRevocationRequest {
         [Int64]$RevocationReason,
 
         [Parameter(Mandatory = $false)]
-        [string]$JobId
+        [string]$JobId,
+
+        # Optional: pre-fetched tags of the specific version (passed by the dispatcher to avoid a
+        # second Get-AzKeyVaultCertificate round-trip). If not provided, the function fetches them.
+        [Parameter(Mandatory = $false)]
+        [System.Collections.IDictionary]$ExistingTags
     )
 
     # get the specific version of the certificate from the key vault, to extract its serial number
@@ -1459,20 +1490,30 @@ function New-CertificateRevocationRequest {
 
     # disable the specific version in key vault and tag it with revocation audit metadata.
     # The Key Vault Update Certificate PATCH endpoint replaces tags wholesale, so we must
-    # read the existing tags on this version, merge our revocation keys, and write back.
+    # start from the existing tags on this version, merge our revocation keys, and write back.
     Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Disabling certificate $CertificateName version $CertificateVersion in key vault $($VaultName) and tagging it as revoked..."
-    try {
-        $existingVersion = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion
+
+    # Source the existing tags: prefer the caller-provided snapshot to avoid a second round-trip;
+    # otherwise fetch the version now.
+    $sourceTags = $null
+    if ($PSBoundParameters.ContainsKey('ExistingTags') -and $null -ne $ExistingTags) {
+        $sourceTags = $ExistingTags
     }
-    catch {
-        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error reading certificate $CertificateName version $CertificateVersion from key vault $VaultName for tag merge", $_.Exception)
+    else {
+        try {
+            $existingVersion = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion
+        }
+        catch {
+            throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error reading certificate $CertificateName version $CertificateVersion from key vault $VaultName for tag merge", $_.Exception)
+        }
+        if ($null -ne $existingVersion) { $sourceTags = $existingVersion.Tags }
     }
 
     # build merged tag set: start from existing tags (if any), then overlay revocation metadata
     $mergedTags = @{}
-    if ($null -ne $existingVersion -and $null -ne $existingVersion.Tags) {
-        foreach ($k in $existingVersion.Tags.Keys) {
-            $mergedTags[$k] = [string]$existingVersion.Tags[$k]
+    if ($null -ne $sourceTags) {
+        foreach ($k in $sourceTags.Keys) {
+            $mergedTags[$k] = [string]$sourceTags[$k]
         }
     }
     $mergedTags['Revoked']          = 'true'
@@ -1554,37 +1595,33 @@ if ([string]::IsNullOrEmpty($PfxRootFolder)) {
     Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-pfxrootfolder' is missing or empty. Ensure this variable exists in the automation account."
 }
 
-# Validate SMTP variables
-# Case 1: SmtpServer is empty or missing - all other SMTP variables must also be empty
+# Validate SMTP variables.
+# - If SmtpServer is empty, no other SMTP variable may be set.
+# - If SmtpServer is set, FromAddress is required; SmtpUser and SmtpPassword must be both set or both empty.
 if ([string]::IsNullOrEmpty($SmtpServer)) {
-    if (-not [string]::IsNullOrEmpty($FromAddress)) {
-        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtpfrom' is set, but 'certlc-smtpserver' is missing or empty. When SmtpServer is not configured, all other SMTP variables must be missing or empty."
-    }
-    if (-not [string]::IsNullOrEmpty($SmtpUser)) {
-        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtpuser' is set, but 'certlc-smtpserver' is missing or empty. When SmtpServer is not configured, all other SMTP variables must be missing or empty."
-    }
-    if (-not [string]::IsNullOrEmpty($SmtpPassword)) {
-        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtppassword' is set, but 'certlc-smtpserver' is missing or empty. When SmtpServer is not configured, all other SMTP variables must be missing or empty."
+    foreach ($pair in @(
+            @{ Name = 'certlc-smtpfrom';     Value = $FromAddress },
+            @{ Name = 'certlc-smtpuser';     Value = $SmtpUser },
+            @{ Name = 'certlc-smtppassword'; Value = $SmtpPassword }
+        )) {
+        if (-not [string]::IsNullOrEmpty($pair.Value)) {
+            Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable '$($pair.Name)' is set, but 'certlc-smtpserver' is missing or empty. When SmtpServer is not configured, all other SMTP variables must be missing or empty."
+        }
     }
     Write-CertLCLog -Section 'Dispatcher' -Message 'SMTP: Email notifications are disabled (SmtpServer is not configured).'
 }
-# Case 2: SmtpServer is set - validate FromAddress and authentication variables
 else {
     if ([string]::IsNullOrEmpty($FromAddress)) {
         Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtpserver' is set, but 'certlc-smtpfrom' is missing or empty. Both must be set to send email."
     }
-    # Check SmtpUser and SmtpPassword: both must be set or both must be empty
     $userSet = -not [string]::IsNullOrEmpty($SmtpUser)
     $passSet = -not [string]::IsNullOrEmpty($SmtpPassword)
-    if ($userSet -and -not $passSet) {
-        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtpuser' is set, but 'certlc-smtppassword' is missing or empty. Both must be set to use authentication, or both must be missing or empty for unauthenticated email."
-    }
-    if ($passSet -and -not $userSet) {
-        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variable 'certlc-smtppassword' is set, but 'certlc-smtpuser' is missing or empty. Both must be set to use authentication, or both must be missing or empty for unauthenticated email."
+    if ($userSet -xor $passSet) {
+        Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "The automation account variables 'certlc-smtpuser' and 'certlc-smtppassword' must be both set (to use SMTP authentication) or both empty (for unauthenticated email). Currently only one of them is set."
     }
 }
 
-# prepare the smtp credentials (only if SmtpServer is configured)
+# Prepare the SMTP credentials (only if SmtpServer is configured)
 $SmtpCredential = $null
 if (-not [string]::IsNullOrEmpty($SmtpServer)) {
     if (-not [string]::IsNullOrEmpty($SmtpUser) -and -not [string]::IsNullOrEmpty($SmtpPassword)) {
@@ -1596,6 +1633,14 @@ if (-not [string]::IsNullOrEmpty($SmtpServer)) {
     else {
         Write-CertLCLog -Section 'Dispatcher' -Message 'SMTP: No authentication will be used to send email. Ensure the SMTP server allows unauthenticated email from this host!' -Level 'Warning'
     }
+}
+
+# Common SMTP arguments, splatted by Write-CertLCLogAndThrow and Send-SuccessNotification call sites.
+# Splatting an empty/null SmtpServer is intentional: the helpers treat that as "SMTP disabled".
+$smtpArgs = @{
+    SmtpServer     = $SmtpServer
+    FromAddress    = $FromAddress
+    SmtpCredential = $SmtpCredential
 }
 
 # Check if we have the jsonRequestBody parameter
@@ -1787,7 +1832,7 @@ switch ($requestBody.type) {
         # get the OID of the Certificate Template
         $templateExtension = $cert.Certificate.Extensions | Where-Object { $_.Oid.FriendlyName -eq 'Certificate Template Information' }
         if ($null -eq $templateExtension) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message 'Error getting template information from certificate: the Certificate Template Information extension was not found.' -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message 'Error getting template information from certificate: the Certificate Template Information extension was not found.' -NotifyTo $NotifyTo @smtpArgs
         }
         # $templateExtension.Format($false) returns a string like:
         # - Template=Flab-ShortWebServer(1.3.6.1.4.1.311.21.8.15431357.2613787.6440092.16459852.14380503.11.12399345.16691736), Major Version Number=100, Minor Version Number=5
@@ -1797,7 +1842,7 @@ switch ($requestBody.type) {
         # extract the OID using a regex working for both cases
         $regex = [regex]'(?<=Template=(?:[^\(]*\()?)(\d+(?:\.\d+)+)'
         if (-not $regex.IsMatch($asn)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error getting OID from certificate: Template OID not found in string: $asn" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error getting OID from certificate: Template OID not found in string: $asn" -NotifyTo $NotifyTo @smtpArgs
         }
         $oid = $regex.Match($asn).Value
 
@@ -1807,17 +1852,17 @@ switch ($requestBody.type) {
             $certificateTemplateName = Find-TemplateName -cnOrDisplayNameOrOid $oid
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error resolving template name for OID $oid" -Inner $_.Exception -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error resolving template name for OID $oid" -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs
         }
         if ([string]::IsNullOrEmpty($certificateTemplateName)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error resolving template name for OID $($oid): template not found in AD." -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error resolving template name for OID $($oid): template not found in AD." -NotifyTo $NotifyTo @smtpArgs
         }
         Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "Template name found for OID $($oid) is: $certificateTemplateName"
 
         # Hostname from the certificate tags
         $Hostname = $cert.Tags['Hostname']
         if ([string]::IsNullOrWhiteSpace($Hostname)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Missing mandatory Hostname tag on certificate $CertificateName in vault $VaultName." -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Missing mandatory Hostname tag on certificate $CertificateName in vault $VaultName." -NotifyTo $NotifyTo @smtpArgs
         }
         Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "Hostname: $Hostname"
 
@@ -1826,7 +1871,7 @@ switch ($requestBody.type) {
         $PfxProtectTo = Convert-PfxProtectToFromTag -TagValue $rawPfxProtectTo
         # After normalization functions, simply checking truthiness is enough; avoid .Count under StrictMode on potential scalars
         if (-not $PfxProtectTo) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Missing mandatory PfxProtectTo tag on certificate $CertificateName in vault $VaultName." -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Missing mandatory PfxProtectTo tag on certificate $CertificateName in vault $VaultName." -NotifyTo $NotifyTo @smtpArgs
         }
         Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "PfxProtectTo principals: $($PfxProtectTo -join ', ')"
 
@@ -1847,19 +1892,14 @@ switch ($requestBody.type) {
             New-CertificateCreationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateTemplateName $certificateTemplateName -CertificateSubject $CertificateSubject -CertificateDnsNames $CertificateDnsNames -CA $CA -Hostname $Hostname -PfxProtectTo $PfxProtectTo -NotifyTo $NotifyTo
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message 'Error processing certificate creation request' -Inner $_.Exception -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message 'Error processing certificate creation request' -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs
         }
 
         # send notification email if requested and SMTP is configured
-        if ($NotifyTo -and -not [string]::IsNullOrEmpty($SmtpServer)) {
-            $subject = "Certificate $CertificateName renewed successfully"
-            $fragment = [System.Net.WebUtility]::HtmlEncode("A new version of certificate $CertificateName has been successfully renewed in the Key Vault $VaultName.")
-            $body = $CertificateNotificationEmailBodyHtml -replace '__CONTENT__', $fragment
-            Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $fromAddress -To $NotifyTo -Subject $subject -Body $body -SmtpCredential $SmtpCredential
-        }
-        elseif ($NotifyTo -and [string]::IsNullOrEmpty($SmtpServer)) {
-            Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "Notification requested but SMTP is not configured. Skipping email notification." -Level 'Warning'
-        }
+        Send-SuccessNotification -Section 'Dispatcher.Renewal' `
+            -Subject "Certificate $CertificateName renewed successfully" `
+            -BodyText "A new version of certificate $CertificateName has been successfully renewed in the Key Vault $VaultName." `
+            -NotifyTo $NotifyTo @smtpArgs
 
         # confirm renewal
         Write-CertLCLog -Section 'Dispatcher.Renewal' -Message "Certificate $CertificateName was successfully renewed."
@@ -1894,12 +1934,12 @@ switch ($requestBody.type) {
 
         # VaultName: presence and non-empty check
         if ([string]::IsNullOrEmpty($VaultName)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.VaultName' in request body!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.VaultName' in request body!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # CertificateName: presence and non-empty check
         if ([string]::IsNullOrEmpty($CertificateName)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.ObjectName' in request body!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.ObjectName' in request body!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # CertificateName: check if the certificate already exists in the key vault
@@ -1907,15 +1947,15 @@ switch ($requestBody.type) {
             $deletedCert = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -InRemovedState
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error checking for deleted certificate' -Inner $_.Exception -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error checking for deleted certificate' -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs
         }
         if (($null -ne $deletedCert) -and ($null -ne $deletedCert.DeletedDate)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Certificate $CertificateName is deleted since $($deletedCert.DeletedDate). Purge it or use a different name." -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Certificate $CertificateName is deleted since $($deletedCert.DeletedDate). Purge it or use a different name." -NotifyTo $NotifyTo @smtpArgs
         }
 
         # CertificateTemplate: presence and non-empty check
         if ([string]::IsNullOrEmpty($CertificateTemplate)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.CertificateTemplate' in request body!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.CertificateTemplate' in request body!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # CertificateTemplate: check if the template exists in AD; caller may have specified the template name (CN) or the display name or the OID. We need the 'name' attribute
@@ -1923,39 +1963,39 @@ switch ($requestBody.type) {
             $CertificateTemplateName = Find-TemplateName -cnOrDisplayNameOrOid $CertificateTemplate
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error resolving template name' -Inner $_.Exception -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error resolving template name' -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs
         }
         if ([string]::IsNullOrEmpty($CertificateTemplateName)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Certificate template $CertificateTemplate not found in Active Directory!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Certificate template $CertificateTemplate not found in Active Directory!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # CertificateSubject: presence and non-empty check
         if ([string]::IsNullOrEmpty($CertificateSubject)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.CertificateSubject' in request body!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.CertificateSubject' in request body!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # DnsNames (optional, but if specified, must be an array)
         if ($CertificateDnsNames -and $CertificateDnsNames -isnot [array]) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Parameter 'CertificateDnsNames' is not an array!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Parameter 'CertificateDnsNames' is not an array!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # Hostname
         if ([string]::IsNullOrWhiteSpace($Hostname)) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.Hostname' in request body!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing or empty mandatory string parameter: 'data.Hostname' in request body!" -NotifyTo $NotifyTo @smtpArgs
         }
         $Hostname = $Hostname.Trim().ToLower()
         if ($Hostname -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9\-\.]{0,253})$') {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Hostname '$Hostname' is not valid!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Hostname '$Hostname' is not valid!" -NotifyTo $NotifyTo @smtpArgs
         }
 
         # PfxProtectTo
         if (-not $PfxProtectTo) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing mandatory parameter 'PfxProtectTo'!" -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message "Missing mandatory parameter 'PfxProtectTo'!" -NotifyTo $NotifyTo @smtpArgs
         }
         $PfxProtectTo = Format-PfxProtectTo -InputValue $PfxProtectTo
         # Avoid .Count: Format-PfxProtectTo guarantees array; empty array evaluates to $false
         if (-not $PfxProtectTo) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'PfxProtectTo list is empty after normalization!' -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'PfxProtectTo list is empty after normalization!' -NotifyTo $NotifyTo @smtpArgs
         }
 
         # end of validation. Now process the new certificate request
@@ -1971,19 +2011,14 @@ switch ($requestBody.type) {
             New-CertificateCreationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateTemplateName $CertificateTemplateName -CertificateSubject $CertificateSubject -CertificateDnsNames $CertificateDnsNames -CA $CA -Hostname $Hostname -PfxProtectTo $PfxProtectTo -NotifyTo $NotifyTo
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error processing new certificate request' -Inner $_.Exception -NotifyTo $NotifyTo -SmtpServer $SmtpServer -FromAddress $FromAddress -SmtpCredential $SmtpCredential
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Creation' -Message 'Error processing new certificate request' -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs
         }
 
         # send notification email if requested and SMTP is configured
-        if ($NotifyTo -and -not [string]::IsNullOrEmpty($SmtpServer)) {
-            $subject = "Certificate $CertificateName created successfully"
-            $fragment = [System.Net.WebUtility]::HtmlEncode("A new certificate $CertificateName has been successfully created in the Key Vault $VaultName.")
-            $body = $CertificateNotificationEmailBodyHtml -replace '__CONTENT__', $fragment
-            Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $fromAddress -To $NotifyTo -Subject $subject -Body $body -SmtpCredential $SmtpCredential
-        }
-        elseif ($NotifyTo -and [string]::IsNullOrEmpty($SmtpServer)) {
-            Write-CertLCLog -Section 'Dispatcher.Creation' -Message "Notification requested but SMTP is not configured. Skipping email notification." -Level 'Warning'
-        }
+        Send-SuccessNotification -Section 'Dispatcher.Creation' `
+            -Subject "Certificate $CertificateName created successfully" `
+            -BodyText "A new certificate $CertificateName has been successfully created in the Key Vault $VaultName." `
+            -NotifyTo $NotifyTo @smtpArgs
 
         # confirm creation
         Write-CertLCLog -Section 'Dispatcher.Creation' -Message "Certificate $CertificateName was successfully created."
@@ -2083,7 +2118,9 @@ switch ($requestBody.type) {
 
         Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Performing certificate revocation for certificate $CertificateName version $CertificateVersion in vault $VaultName with reason $RevocationReason..."
         try {
-            New-CertificateRevocationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateVersion $CertificateVersion -RevocationReason $RevocationReason -JobId $jobId
+            # Pass the already-fetched version tags so New-CertificateRevocationRequest does not
+            # need a second Get-AzKeyVaultCertificate round-trip just to merge them.
+            New-CertificateRevocationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateVersion $CertificateVersion -RevocationReason $RevocationReason -JobId $jobId -ExistingTags $cert.Tags
         }
         catch {
             Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message 'Error processing certificate revocation request' -Inner $_.Exception -NotifyTo $NotifyTo
@@ -2099,16 +2136,10 @@ switch ($requestBody.type) {
         }
 
         # send notification email if requested and SMTP is configured
-        if ($NotifyTo -and -not [string]::IsNullOrEmpty($SmtpServer)) {
-            $subject = "Certificate $CertificateName version revoked successfully"
-            $fragmentText = "The version $CertificateVersion of certificate $CertificateName has been revoked at the CA and disabled in Key Vault $VaultName. The certificate object remains in the vault for audit purposes; other versions (if any) are unaffected."
-            $fragment = [System.Net.WebUtility]::HtmlEncode($fragmentText)
-            $body = $CertificateNotificationEmailBodyHtml -replace '__CONTENT__', $fragment
-            Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $fromAddress -To $NotifyTo -Subject $subject -Body $body -smtpCredential $SmtpCredential
-        }
-        elseif ($NotifyTo -and [string]::IsNullOrEmpty($SmtpServer)) {
-            Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Notification requested but SMTP is not configured. Skipping email notification." -Level 'Warning'
-        }
+        Send-SuccessNotification -Section 'Dispatcher.Revocation' `
+            -Subject "Certificate $CertificateName version revoked successfully" `
+            -BodyText "The version $CertificateVersion of certificate $CertificateName has been revoked at the CA and disabled in Key Vault $VaultName. The certificate object remains in the vault for audit purposes; other versions (if any) are unaffected." `
+            -NotifyTo $NotifyTo @smtpArgs
 
         # confirm revocation
         Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Certificate $CertificateName version $CertificateVersion was successfully revoked (CA: serial revoked; KeyVault: version disabled and tagged)."

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -888,7 +888,18 @@ function Find-TemplateName {
     $searchRoot = "LDAP://CN=Certificate Templates,CN=Public Key Services,CN=Services,$configDN"
     $entry = [ADSI]$searchRoot
     $searcher = New-Object DirectoryServices.DirectorySearcher $entry
-    $searcher.Filter = "(&(objectClass=pKICertificateTemplate)(|(cn=$cnOrDisplayNameOrOid)(displayName=$cnOrDisplayNameOrOid)(msPKI-Cert-Template-OID=$cnOrDisplayNameOrOid)))"
+
+    # S2: escape the search value per RFC 4515 before interpolation into the LDAP filter.
+    # Defence-in-depth: today $cnOrDisplayNameOrOid comes from trusted sources (Event Grid
+    # payload or CertEnroll OID), but escaping costs nothing and prevents future regressions
+    # if the input ever becomes user-controlled. Escapes: \ * ( ) NUL -> \5c \2a \28 \29 \00.
+    $escaped = $cnOrDisplayNameOrOid `
+        -replace '\\', '\5c' `
+        -replace '\*',  '\2a' `
+        -replace '\(',  '\28' `
+        -replace '\)',  '\29' `
+        -replace "`0",  '\00'
+    $searcher.Filter = "(&(objectClass=pKICertificateTemplate)(|(cn=$escaped)(displayName=$escaped)(msPKI-Cert-Template-OID=$escaped)))"
     $searcher.PropertiesToLoad.Add('name') | Out-Null
     $result = $searcher.FindOne()
     if ($null -eq $result) {

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -2252,6 +2252,22 @@ switch ($requestBody.type) {
             $notifyTo = $rawNotifyTo.Split(';') | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
         }
 
+        # Idempotency guard: if this version is already marked as revoked, exit cleanly with a
+        # clear message instead of attempting the revocation again. Without this check the flow
+        # would proceed and fail later inside New-CertificateRevocationRequest at the
+        # Get-AzKeyVaultSecret call (Key Vault refuses to release the secret material of a
+        # disabled version), producing a misleading "Error getting certificate from key vault"
+        # log line. Mirrors the renewal-side check that skips auto-renewal of revoked versions.
+        $revokedTag = if ($cert.Tags -and $cert.Tags.ContainsKey('Revoked')) { [string]$cert.Tags['Revoked'] } else { $null }
+        if ($revokedTag -and $revokedTag.Trim().ToLowerInvariant() -eq 'true') {
+            $revokedAt     = if ($cert.Tags.ContainsKey('RevokedAt'))        { [string]$cert.Tags['RevokedAt'] }        else { '<unknown>' }
+            $revokedReason = if ($cert.Tags.ContainsKey('RevocationReason')) { [string]$cert.Tags['RevocationReason'] } else { '<unknown>' }
+            $revokedJobId  = if ($cert.Tags.ContainsKey('RevokedJobId'))     { [string]$cert.Tags['RevokedJobId'] }     else { '<unknown>' }
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' `
+                -Message "Certificate '$CertificateName' version '$CertificateVersion' (thumbprint $CertificateThumbprint) is ALREADY REVOKED (RevokedAt=$revokedAt, RevocationReason=$revokedReason, RevokedJobId=$revokedJobId). Ignoring duplicate revocation request." `
+                -NotifyTo $notifyTo @smtpArgs
+        }
+
         # end of validation. Now process the certificate revocation request
 
         Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Performing certificate revocation for certificate $CertificateName version $CertificateVersion in vault $VaultName with reason $RevocationReason..."

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -311,7 +311,7 @@ function Write-CertLCLog {
 .PARAMETER SmtpServer
     The SMTP server to use for sending the email.
 
-.PARAMETER fromAddress
+.PARAMETER FromAddress
     The from address to use for the email.
 
 .PARAMETER To
@@ -323,12 +323,12 @@ function Write-CertLCLog {
 .PARAMETER Body
     The body of the email (HTML format).
 
-.PARAMETER smtpCredential
+.PARAMETER SmtpCredential
     An optional PSCredential for SMTP authentication.
 
 .EXAMPLE
     $smtpCredential = Get-Credential -UserName "smtpuser" -Message "Enter SMTP password"
-    Send-NotificationEmail -SmtpServer "smtp.example.com" -fromAddress "<sender@example.com>" -To "<recipient@example.com>" -Subject "Test Email" -Body "<h1>This is a test email</h1>" -smtpCredential $smtpCredential
+    Send-NotificationEmail -SmtpServer "smtp.example.com" -FromAddress "<sender@example.com>" -To "<recipient@example.com>" -Subject "Test Email" -Body "<h1>This is a test email</h1>" -SmtpCredential $smtpCredential
 
 .NOTES
     This function does not throw on failure, but logs a warning instead, to avoid a loop if called from Write-CertLCLogAndThrow.
@@ -340,22 +340,22 @@ function Send-NotificationEmail {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$SmtpServer,
-        [Parameter(Mandatory)][string]$fromAddress,
+        [Parameter(Mandatory)][string]$FromAddress,
         [Parameter(Mandatory)][string[]]$To,
         [Parameter(Mandatory)][string]$Subject,
         [Parameter(Mandatory)][string]$Body,
-        [Parameter()][pscredential]$smtpCredential
+        [Parameter()][pscredential]$SmtpCredential
     )
 
     try {
 
-        if ($null -eq $smtpCredential) {
+        if ($null -eq $SmtpCredential) {
             # send without authentication
-            Send-MailMessage -SmtpServer $SmtpServer -From $fromAddress -To $To -Subject $Subject -Body $Body -BodyAsHtml:$true -WarningAction:SilentlyContinue
+            Send-MailMessage -SmtpServer $SmtpServer -From $FromAddress -To $To -Subject $Subject -Body $Body -BodyAsHtml:$true -WarningAction:SilentlyContinue
         }
         else {
             # send with authentication
-            Send-MailMessage -SmtpServer $SmtpServer -From $fromAddress -To $To -Subject $Subject -Body $Body -BodyAsHtml:$true -Credential $smtpCredential -WarningAction:SilentlyContinue
+            Send-MailMessage -SmtpServer $SmtpServer -From $FromAddress -To $To -Subject $Subject -Body $Body -BodyAsHtml:$true -Credential $SmtpCredential -WarningAction:SilentlyContinue
         }
 
         Write-CertLCLog -Message "Notification email sent to: $($To -join ', ')" -Section 'Send-NotificationEmail'
@@ -438,7 +438,7 @@ function Send-SuccessNotification {
     .PARAMETER SmtpServer
         The SMTP server to use for sending email notifications.
 
-    .PARAMETER fromAddress
+    .PARAMETER FromAddress
         The from address to use for sending email notifications.
 
     .PARAMETER SmtpCredential
@@ -452,7 +452,7 @@ function Send-SuccessNotification {
         # some code that may fail
     }
     catch {
-        Write-CertLCLogAndThrow -Message "Operation failed" -Section "MyFunction" -CorrelationId $correlationId -InnerException $_.Exception -Context @{ detail = "additional info" } -NotifyTo @("admin@example.com") -SmtpServer "smtp.example.com" -fromAddress "noreply@example.com" -SmtpCredential $smtpCredential
+        Write-CertLCLogAndThrow -Message "Operation failed" -Section "MyFunction" -CorrelationId $correlationId -InnerException $_.Exception -Context @{ detail = "additional info" } -NotifyTo @("admin@example.com") -SmtpServer "smtp.example.com" -FromAddress "noreply@example.com" -SmtpCredential $smtpCredential
     }
 
 #>
@@ -467,7 +467,7 @@ function Write-CertLCLogAndThrow {
         [Parameter()][hashtable]$Context,
         [Parameter()][string[]]$NotifyTo,
         [Parameter()][string]$SmtpServer,
-        [Parameter()][string]$fromAddress,
+        [Parameter()][string]$FromAddress,
         [Parameter()][pscredential]$SmtpCredential
     )
 
@@ -505,7 +505,7 @@ function Write-CertLCLogAndThrow {
 
         $fragment = [System.Net.WebUtility]::HtmlEncode($fragment)
         $body = $CertificateErrorEmailBodyHtml -replace '__CONTENT__', $fragment
-        Send-NotificationEmail -SmtpServer $SmtpServer -fromAddress $fromAddress -To $NotifyTo -Subject $subject -Body $body -SmtpCredential $SmtpCredential
+        Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $FromAddress -To $NotifyTo -Subject $subject -Body $body -SmtpCredential $SmtpCredential
     }
     elseif ($NotifyTo -and [string]::IsNullOrEmpty($SmtpServer)) {
         Write-CertLCLog -Level 'Warning' -Message "Error notification requested but SMTP is not configured. Skipping email notification." -Section $Section
@@ -1048,16 +1048,21 @@ function New-CertificateCreationRequest {
         $CertRequest = New-Object -ComObject CertificateAuthority.Request
         $CertRequestStatus = $CertRequest.Submit(0x1, $csr, "CertificateTemplate:$CertificateTemplateName", $CA)
 
+        # ICertRequest::Submit disposition codes (see wincrypt.h)
+        $CR_DISP_DENIED            = 2
+        $CR_DISP_ISSUED            = 3
+        $CR_DISP_UNDER_SUBMISSION  = 5
+
         switch ($CertRequestStatus) {
-            2 {
+            $CR_DISP_DENIED {
                 throw [System.Exception]::new("New-CertificateCreationRequest: CA: Request was denied. Check the CA $CA for details.")
             }
-            3 {
+            $CR_DISP_ISSUED {
                 Write-CertLCLog -Section 'New-CertificateCreationRequest' -Message "CA: Certificate Request for $CertificateName submitted successfully."
                 $CertEncoded = $CertRequest.GetCertificate(0x0)
                 Write-CertLCLog -Section 'New-CertificateCreationRequest' -Message "Certificate received from CA $CA"
             }
-            5 {
+            $CR_DISP_UNDER_SUBMISSION {
                 throw [System.Exception]::new("New-CertificateCreationRequest: CA: Request to $CA is pending. This runbook expects immediate issuance. Review template/CA configuration.")
             }
             default {
@@ -1564,7 +1569,7 @@ catch {
 }
 
 # set context
-Set-AzContext -SubscriptionName $AzureConnection.Subscription -DefaultProfile $AzureConnection | Out-Null
+Set-AzContext -SubscriptionId $AzureConnection.Subscription.Id -DefaultProfile $AzureConnection | Out-Null
 
 # Check if the script is running on Azure or on hybrid worker; assign jobId accordingly.
 # https://rakhesh.com/azure/azure-automation-powershell-variables/
@@ -1638,7 +1643,7 @@ $SmtpCredential = $null
 if (-not [string]::IsNullOrEmpty($SmtpServer)) {
     if (-not [string]::IsNullOrEmpty($SmtpUser) -and -not [string]::IsNullOrEmpty($SmtpPassword)) {
         $SmtpSecurePassword = ConvertTo-SecureString -String $SmtpPassword -AsPlainText -Force
-        $SmtpCredential = New-Object System.Management.Automation.PSCredential ($SmtpUser, $SmtpSecurePassword)
+        $SmtpCredential = [pscredential]::new($SmtpUser, $SmtpSecurePassword)
         $SmtpSecurePassword = $null
         Write-CertLCLog -Section 'Dispatcher' -Message 'SMTP: Authentication will be used to send email.'
     }

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -968,7 +968,11 @@ function New-CertificateCreationRequest {
         [Parameter(Mandatory = $true)][string]$CA,
         [Parameter(Mandatory = $true)][string]$Hostname,
         [Parameter(Mandatory = $true)][string[]]$PfxProtectTo,
-        [Parameter()][string[]]$NotifyTo
+        [Parameter()][string[]]$NotifyTo,
+        # R3: when this request is the second leg of an auto-renewal, the dispatcher
+        # passes the current Automation job id; it is stamped on the new version's tags
+        # for audit symmetry with RevokedJobId.
+        [Parameter()][string]$RenewedJobId
     )
 
     # prepare tags for the certificate
@@ -983,6 +987,9 @@ function New-CertificateCreationRequest {
     # NotifyTo may arrive as a single string or an array; avoid using .Count on a scalar string
     if ($NotifyTo) {
         $tags['NotifyTo'] = (@($NotifyTo) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ';'
+    }
+    if (-not [string]::IsNullOrEmpty($RenewedJobId)) {
+        $tags['RenewedJobId'] = $RenewedJobId
     }
 
     # create certificate CSR - if a previous request is in progress, reuse it
@@ -1906,7 +1913,7 @@ switch ($requestBody.type) {
         Write-CertLCLog -Section 'Dispatcher.Renewal' -Message 'The operation will now continue as a new certificate creation request. See next log entries for details.'
 
         try {
-            New-CertificateCreationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateTemplateName $certificateTemplateName -CertificateSubject $CertificateSubject -CertificateDnsNames $CertificateDnsNames -CA $CA -Hostname $Hostname -PfxProtectTo $PfxProtectTo -NotifyTo $NotifyTo
+            New-CertificateCreationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateTemplateName $certificateTemplateName -CertificateSubject $CertificateSubject -CertificateDnsNames $CertificateDnsNames -CA $CA -Hostname $Hostname -PfxProtectTo $PfxProtectTo -NotifyTo $NotifyTo -RenewedJobId $jobId
         }
         catch {
             Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message 'Error processing certificate creation request' -Inner $_.Exception -NotifyTo $NotifyTo @smtpArgs

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -101,6 +101,18 @@ For certificate revocation requests, the body has a structure like this:
   }
 }
 
+Revocation semantics:
+- The thumbprint may refer to ANY version of the certificate in the key vault (latest or older).
+  The runbook locates the specific version whose x5t matches the supplied thumbprint.
+- The CA revokes the corresponding serial number using the supplied reason code.
+- In Key Vault, the matched version is set to attributes.enabled=false and tagged with
+  Revoked=true, RevokedAt=<UTC ISO-8601>, RevocationReason=<n>, RevokedJobId=<automation job id>.
+  Existing tags on the version (e.g. NotifyTo, Hostname, PfxProtectTo) are preserved.
+- The certificate object and other versions of the same certificate are NEVER deleted or modified.
+- If the revoked version is the latest version of the certificate, a warning is logged and
+  any subsequent CertificateNearExpiry event for the same certificate is ignored by the
+  renewal flow (it checks the latest version's Revoked tag and exits without renewing).
+
 You can also pass the RequestBody parameter explicitly, which must be a JSON string with the same structure as above.
 In this case, use the Start-AzAutomationRunbook cmdlet to start the runbook, passing the jsonRequestBody parameter:
 
@@ -1158,34 +1170,49 @@ function New-CertificateCreationRequest {
 <#
 
 .SYNOPSIS
-    Finds a certificate in Azure Key Vault by thumbprint and returns its name.
+    Finds a certificate version in Azure Key Vault by thumbprint.
 
 .DESCRIPTION
-    This function searches for a certificate in the specified Azure Key Vault using the
-    Key Vault REST API. Given a thumbprint, it enumerates all certificates (with pagination)
-    and returns the certificate name if found, or $null if not found.
+    Searches the specified Azure Key Vault for the version of any certificate whose thumbprint
+    (x5t) matches the supplied value. The thumbprint may correspond to any version of any
+    certificate - current ("latest") or older.
+
+    Algorithm:
+      1. List certificates with GET /certificates?api-version=2025-07-01 (one entry per
+         certificate name; the x5t exposed there is the thumbprint of the latest version
+         only). If a match is found here, the matched version is the latest version of that
+         certificate.
+      2. If no match in step 1, for each certificate listed in step 1 enumerate its versions
+         via GET /certificates/{name}/versions?api-version=2025-07-01 and compare x5t.
+
+    Pagination is handled for both listings via nextLink.
 
 .PARAMETER VaultName
     The name of the Azure Key Vault to query.
 
 .PARAMETER Thumbprint
-    The thumbprint of the certificate to find (hex format).
+    The thumbprint of the certificate version to find (hex format; spaces, dashes and
+    colons are stripped and case is normalized to uppercase).
 
 .OUTPUTS
-    String - The name of the certificate in the vault, or $null if not found.
+    [pscustomobject] with properties:
+      - Name     : certificate name in the vault
+      - Version  : version identifier of the matched version
+      - IsLatest : $true if the matched version is the latest version of the certificate
+    Returns $null when no version with the supplied thumbprint exists in the vault.
 
 .EXAMPLE
-    $certName = Get-CertificateByThumbprint -VaultName "mykeyvault" -Thumbprint "7CB8B52E7BA87B221534BB9B04A7FFF2D3FA59BA"
-    if ($certName) { Write-Host "Found: $certName" }
+    $match = Get-CertificateByThumbprint -VaultName 'mykeyvault' -Thumbprint '7CB8B52E7BA87B221534BB9B04A7FFF2D3FA59BA'
+    if ($match) { "Found $($match.Name) version $($match.Version) (latest: $($match.IsLatest))" }
 
 .NOTES
     Uses Key Vault REST API version 2025-07-01.
-    Requires an active Azure context with appropriate Key Vault permissions.
+    Requires an active Azure context with the certificates/list permission on the vault.
 
 #>
 
 function Get-CertificateByThumbprint {
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -1197,7 +1224,7 @@ function Get-CertificateByThumbprint {
 
     # Normalize the input thumbprint (remove spaces, dashes, colons; convert to uppercase)
     $normalizedThumbprint = ($Thumbprint -replace '[^a-fA-F0-9]', '').ToUpper()
-    
+
     if ([string]::IsNullOrEmpty($normalizedThumbprint)) {
         throw [System.ArgumentException]::new('Get-CertificateByThumbprint: Thumbprint is empty after normalization.', 'Thumbprint')
     }
@@ -1214,6 +1241,12 @@ function Get-CertificateByThumbprint {
         return ($bytes | ForEach-Object { $_.ToString('X2') }) -join ''
     }
 
+    # Helper: Extract the last URL segment (certificate name or version) from a KV resource id
+    $lastSegment = {
+        param([string]$id)
+        return ($id -split '/')[-1]
+    }
+
     # Helper: Invoke Key Vault REST API
     $invokeApi = {
         param([string]$uri)
@@ -1228,42 +1261,88 @@ function Get-CertificateByThumbprint {
         return Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
     }
 
-    # Build the base URI
     $vaultBaseUrl = "https://$VaultName.vault.azure.net"
-    $apiVersion = "2025-07-01"
+    $apiVersion = '2025-07-01'
+
+    # Step 1: enumerate certificates (one entry per cert name; x5t is the LATEST version's thumbprint)
+    # While iterating we also collect the certificate names so step 2 can fall back to per-cert version listings.
+    $certificateNames = New-Object 'System.Collections.Generic.List[string]'
     $uri = "$vaultBaseUrl/certificates?api-version=$apiVersion"
 
-    # Search for the certificate with matching thumbprint (handling pagination)
-    $foundCertName = $null
-    
     try {
-        :searchLoop do {
+        :latestLoop do {
             $response = & $invokeApi $uri
-            
+
             if ($response.value) {
                 foreach ($cert in $response.value) {
+                    # Capture the certificate name for the possible step-2 pass
+                    if ($cert.id) {
+                        # /certificates listing ids have the shape: <vaultBaseUrl>/certificates/<name>
+                        $name = & $lastSegment $cert.id
+                        if (-not [string]::IsNullOrEmpty($name)) {
+                            [void]$certificateNames.Add($name)
+                        }
+                    }
+
                     if ($cert.x5t) {
                         $certThumbprint = & $convertToHex $cert.x5t
-                        
                         if ($certThumbprint -eq $normalizedThumbprint) {
-                            # Extract certificate name from the ID URL
-                            $foundCertName = ($cert.id -split '/certificates/')[-1]
-                            break searchLoop
+                            # We matched against the latest-version thumbprint. The id of the listing
+                            # entry does NOT contain a version segment, so we resolve the latest version
+                            # id explicitly via /certificates/{name}.
+                            $certName = & $lastSegment $cert.id
+                            $bundleUri = "$vaultBaseUrl/certificates/$certName" + "?api-version=$apiVersion"
+                            $bundle = & $invokeApi $bundleUri
+                            $version = & $lastSegment $bundle.id
+                            return [pscustomobject]@{
+                                Name     = $certName
+                                Version  = $version
+                                IsLatest = $true
+                            }
                         }
                     }
                 }
             }
-            
-            # Check for pagination
+
             $uri = $response.nextLink
-            
         } while ($uri)
     }
     catch {
         throw [System.Exception]::new("Get-CertificateByThumbprint: Failed to enumerate certificates in vault '$VaultName'.", $_.Exception)
     }
 
-    return $foundCertName
+    # Step 2: no match against any latest version. Enumerate every cert's versions and compare x5t.
+    try {
+        foreach ($name in $certificateNames) {
+            $uri = "$vaultBaseUrl/certificates/$name/versions?api-version=$apiVersion"
+            do {
+                $response = & $invokeApi $uri
+                if ($response.value) {
+                    foreach ($ver in $response.value) {
+                        if ($ver.x5t) {
+                            $certThumbprint = & $convertToHex $ver.x5t
+                            if ($certThumbprint -eq $normalizedThumbprint) {
+                                # /certificates/{name}/versions listing ids have the shape:
+                                #   <vaultBaseUrl>/certificates/<name>/<version>
+                                $version = & $lastSegment $ver.id
+                                return [pscustomobject]@{
+                                    Name     = $name
+                                    Version  = $version
+                                    IsLatest = $false
+                                }
+                            }
+                        }
+                    }
+                }
+                $uri = $response.nextLink
+            } while ($uri)
+        }
+    }
+    catch {
+        throw [System.Exception]::new("Get-CertificateByThumbprint: Failed to enumerate certificate versions in vault '$VaultName'.", $_.Exception)
+    }
+
+    return $null
 }
 
 #endregion
@@ -1277,17 +1356,27 @@ function Get-CertificateByThumbprint {
 <#
 
 .SYNOPSIS
-    Revoke an existing certificate in Key Vault by sending a revocation request to the specified CA.
+    Revoke a specific version of a certificate by sending a revocation request to the CA, then
+    disable that version in Key Vault and tag it with audit metadata.
 
 .DESCRIPTION
-    This function revokes an existing certificate stored in Azure Key Vault by sending a revocation request to the specified Certificate Authority (CA).
-    The certificate is also deleted from the Key Vault after successful revocation.
+    This function revokes the specified version of a certificate stored in Azure Key Vault:
+      1. Loads the secret of the specific version to extract the X.509 serial number.
+      2. Submits a revocation request to the Certificate Authority (CA) for that serial.
+      3. Disables that Key Vault version (attributes.enabled=false) and tags it with
+         Revoked=true, RevokedAt, RevocationReason, RevokedJobId. Existing tags on the
+         version are preserved (read-merge-write).
+    The certificate object is NEVER deleted from Key Vault. Other versions of the same
+    certificate are not touched.
 
 .PARAMETER VaultName
     The name of the Azure Key Vault where the certificate is stored.
 
 .PARAMETER CertificateName
     The name of the certificate to revoke.
+
+.PARAMETER CertificateVersion
+    The version identifier of the certificate version to revoke.
 
 .PARAMETER RevocationReason
     The reason for revocation, specified as an integer value (0-6) according to the CRLReason codes:
@@ -1299,11 +1388,11 @@ function Get-CertificateByThumbprint {
         5 - Cessation of Operation
         6 - Certificate Hold
 
-.PARAMETER CA
-    The CA from which the certificate will be revoked.
+.PARAMETER JobId
+    The Automation runbook job id; written into the RevokedJobId tag for traceability.
 
 .EXAMPLE
-    New-CertificateRevocationRequest -VaultName "MyKeyVault" -CertificateName "MyCertificate" -RevocationReason 1 -CA "MyCA\MyInstance"
+    New-CertificateRevocationRequest -VaultName 'MyKeyVault' -CertificateName 'MyCertificate' -CertificateVersion 'abc123...' -RevocationReason 1 -JobId $jobId
 
 #>
 function New-CertificateRevocationRequest {
@@ -1316,43 +1405,48 @@ function New-CertificateRevocationRequest {
         [string]$CertificateName,
 
         [Parameter(Mandatory = $true)]
+        [string]$CertificateVersion,
+
+        [Parameter(Mandatory = $true)]
         [ValidateRange(0, 6)]
-        [Int64]$RevocationReason
+        [Int64]$RevocationReason,
+
+        [Parameter(Mandatory = $false)]
+        [string]$JobId
     )
 
-    # get the certificate from the key vault
-    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Certificate $($CertificateName): getting the certificate from key vault $VaultName to obtain details..."
+    # get the specific version of the certificate from the key vault, to extract its serial number
+    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Certificate $($CertificateName) version $($CertificateVersion): getting the version secret from key vault $VaultName to obtain details..."
     try {
-        $certBase64 = Get-AzKeyVaultSecret -VaultName $VaultName -Name $CertificateName -AsPlainText
+        $certBase64 = Get-AzKeyVaultSecret -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion -AsPlainText
     }
     catch {
-        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error getting certificate $CertificateName from key vault $VaultName", $_.Exception)
+        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error getting certificate $CertificateName version $CertificateVersion from key vault $VaultName", $_.Exception)
     }
     if ([string]::IsNullOrEmpty($certBase64)) {
-        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Certificate $CertificateName secret is empty in key vault $VaultName")
+        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Certificate $CertificateName version $CertificateVersion secret is empty in key vault $VaultName")
     }
 
     # convert the base64 string to a byte array and create an X509Certificate2 object
     $certBytes = [Convert]::FromBase64String($certBase64)
     $certBase64 = $null
     $x509Cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certBytes, [string]::Empty, 'Exportable')
-    # $x509Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certBytes, [string]::Empty, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
 
-    # save the serial number
+    # save the serial number of this specific version
     $serialNumber = $x509Cert.SerialNumber
 
     # cleanup objects that are no longer needed
     $x509Cert = $null
     $certBytes = $null
 
-    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "CA: Sending revocation request for certificate $CertificateName to the CA $CA using reason $($RevocationReason)..."
+    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "CA: Sending revocation request for certificate $CertificateName version $CertificateVersion (serial $serialNumber) to the CA $CA using reason $($RevocationReason)..."
 
     try {
         $CertAdmin = New-Object -ComObject CertificateAuthority.Admin
         $CertAdmin.RevokeCertificate($CA, $serialNumber, $RevocationReason, 0)
     }
     catch {
-        throw [System.Exception]::new("New-CertificateRevocationRequest: CA: Error revoking certificate $CertificateName in CA $CA", $_.Exception)
+        throw [System.Exception]::new("New-CertificateRevocationRequest: CA: Error revoking certificate $CertificateName version $CertificateVersion (serial $serialNumber) in CA $CA", $_.Exception)
     }
     finally {
         if ($CertAdmin) {
@@ -1361,17 +1455,42 @@ function New-CertificateRevocationRequest {
         }
     }
 
-    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "CA: Certificate $CertificateName revoked successfully in CA $($CA)."
+    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "CA: Certificate $CertificateName version $CertificateVersion (serial $serialNumber) revoked successfully in CA $($CA)."
 
-    # remove the certificate from the key vault
-    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Removing certificate $CertificateName from key vault $($VaultName)..."
+    # disable the specific version in key vault and tag it with revocation audit metadata.
+    # The Key Vault Update Certificate PATCH endpoint replaces tags wholesale, so we must
+    # read the existing tags on this version, merge our revocation keys, and write back.
+    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Disabling certificate $CertificateName version $CertificateVersion in key vault $($VaultName) and tagging it as revoked..."
     try {
-        Remove-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Force
+        $existingVersion = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion
     }
     catch {
-        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error removing certificate $CertificateName from key vault $VaultName", $_.Exception)
+        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error reading certificate $CertificateName version $CertificateVersion from key vault $VaultName for tag merge", $_.Exception)
     }
-    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Certificate $CertificateName removed from key vault $($VaultName)."
+
+    # build merged tag set: start from existing tags (if any), then overlay revocation metadata
+    $mergedTags = @{}
+    if ($null -ne $existingVersion -and $null -ne $existingVersion.Tags) {
+        foreach ($k in $existingVersion.Tags.Keys) {
+            $mergedTags[$k] = [string]$existingVersion.Tags[$k]
+        }
+    }
+    $mergedTags['Revoked']          = 'true'
+    $mergedTags['RevokedAt']        = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $mergedTags['RevocationReason'] = [string]$RevocationReason
+    if (-not [string]::IsNullOrEmpty($JobId)) {
+        $mergedTags['RevokedJobId'] = $JobId
+    }
+
+    # Update-AzKeyVaultCertificate wraps PATCH /certificates/{name}/{version}: -Enable $false and
+    # -Tag are applied in a single atomic call.
+    try {
+        $null = Update-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion -Enable $false -Tag $mergedTags -PassThru -ErrorAction Stop
+    }
+    catch {
+        throw [System.Exception]::new("New-CertificateRevocationRequest: KeyVault: Error disabling/tagging certificate $CertificateName version $CertificateVersion in key vault $VaultName", $_.Exception)
+    }
+    Write-CertLCLog -Section 'New-CertificateRevocationRequest' -Message "KeyVault: Certificate $CertificateName version $CertificateVersion in key vault $($VaultName) has been disabled and tagged as revoked. The certificate object and other versions (if any) are left untouched."
 }
 
 #endregion
@@ -1623,6 +1742,23 @@ switch ($requestBody.type) {
         }
         if ($null -eq $cert) {
             Write-CertLCLogAndThrow -Section 'Dispatcher.Renewal' -Message "Error getting certificate details for $CertificateName from vault $($VaultName): empty response! Certificate may not exist in the vault."
+        }
+
+        # If the latest version of this certificate was previously revoked by the runbook, the
+        # CertLC revocation flow tagged it with Revoked=true and set it to disabled. Auto-renewal
+        # in that situation would silently re-issue the certificate (new version, new serial) and
+        # effectively "un-revoke" the certificate name on the CA side. Skip the renewal in this
+        # case and require an explicit operator action (e.g. issue a brand new certificate or
+        # clear the Revoked tag manually).
+        $latestRevokedTag = $null
+        if ($null -ne $cert.Tags -and $cert.Tags.ContainsKey('Revoked')) {
+            $latestRevokedTag = [string]$cert.Tags['Revoked']
+        }
+        if ($latestRevokedTag -and $latestRevokedTag.Trim().ToLowerInvariant() -eq 'true') {
+            $revokedAt = if ($cert.Tags.ContainsKey('RevokedAt')) { [string]$cert.Tags['RevokedAt'] } else { '<unknown>' }
+            $revokedReason = if ($cert.Tags.ContainsKey('RevocationReason')) { [string]$cert.Tags['RevocationReason'] } else { '<unknown>' }
+            Write-CertLCLog -Section 'Dispatcher.Renewal' -Level 'Warning' -Message "Skipping auto-renewal of certificate $CertificateName in vault $($VaultName): the latest version is tagged as revoked (RevokedAt=$revokedAt, RevocationReason=$revokedReason). Issue a new certificate explicitly or clear the Revoked tag to resume auto-renewal."
+            return
         }
 
         # get NotifyTo from the certificate tags (optional)
@@ -1902,57 +2038,71 @@ switch ($requestBody.type) {
 
         if ($RevocationReason -notin 0, 1, 2, 3, 4, 5, 6) { Write-CertLCLogAndThrow -Section 'Dispatcher' -Message "Revocation request validation: Invalid integer value for 'data.RevocationReason'. Supported: 0-6." }
 
-        # before processing the request, we need to find the certificate by thumbprint
-        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Searching for certificate with thumbprint $CertificateThumbprint in key vault $VaultName..."
-        $CertificateName = $null
+        # before processing the request, we need to find the matching certificate version by thumbprint
+        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Searching for certificate version with thumbprint $CertificateThumbprint in key vault $VaultName..."
+        $match = $null
         try {
-            $CertificateName = Get-CertificateByThumbprint -VaultName $VaultName -Thumbprint $CertificateThumbprint
+            $match = Get-CertificateByThumbprint -VaultName $VaultName -Thumbprint $CertificateThumbprint
         }
         catch {
             Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "Error finding certificate with thumbprint $CertificateThumbprint in vault $VaultName" -Inner $_.Exception
         }
-        if ($null -eq $CertificateName) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "No certificate found with thumbprint $CertificateThumbprint in vault $VaultName."
+        if ($null -eq $match) {
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "No certificate version found with thumbprint $CertificateThumbprint in vault $VaultName."
         }
-        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Found certificate '$CertificateName' matching thumbprint $CertificateThumbprint in vault $VaultName."
+        $CertificateName    = $match.Name
+        $CertificateVersion = $match.Version
+        $IsLatestVersion    = [bool]$match.IsLatest
+        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Found certificate '$CertificateName' version '$CertificateVersion' (IsLatest=$IsLatestVersion) matching thumbprint $CertificateThumbprint in vault $VaultName."
 
-        # Get the full certificate object to retrieve tags
+        # Get the matched certificate version to retrieve its tags (NotifyTo is read from the specific version,
+        # so older versions that carry their own NotifyTo are honored).
         $cert = $null
         try {
-            $cert = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName
+            $cert = Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertificateName -Version $CertificateVersion
         }
         catch {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "Error getting certificate details for $CertificateName from vault $VaultName" -Inner $_.Exception
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "Error getting certificate details for $CertificateName version $CertificateVersion from vault $VaultName" -Inner $_.Exception
         }
         if ($null -eq $cert) {
-            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "Error getting certificate details for $CertificateName from vault $($VaultName): empty response!"
+            Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message "Error getting certificate details for $CertificateName version $CertificateVersion from vault $($VaultName): empty response!"
         }
 
-        # get NotifyTo from the certificate tags (optional)
+        # get NotifyTo from the certificate version tags (optional)
         $rawNotifyTo = $cert.Tags['NotifyTo']
         if ([string]::IsNullOrWhiteSpace($rawNotifyTo)) {
             $notifyTo = $null
-            Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "No NotifyTo addresses found for certificate $CertificateName in vault $VaultName."
+            Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "No NotifyTo addresses found for certificate $CertificateName version $CertificateVersion in vault $VaultName."
         }
         else {
-            Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "NotifyTo addresses found for certificate $CertificateName in vault ${VaultName}: $rawNotifyTo"
+            Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "NotifyTo addresses found for certificate $CertificateName version $CertificateVersion in vault ${VaultName}: $rawNotifyTo"
             $notifyTo = $rawNotifyTo.Split(';') | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
         }
 
         # end of validation. Now process the certificate revocation request
 
-        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Performing certificate revocation request for certificate $CertificateName in vault $VaultName with reason $RevocationReason..."
+        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Performing certificate revocation for certificate $CertificateName version $CertificateVersion in vault $VaultName with reason $RevocationReason..."
         try {
-            New-CertificateRevocationRequest -VaultName $VaultName -CertificateName $CertificateName -RevocationReason $RevocationReason
+            New-CertificateRevocationRequest -VaultName $VaultName -CertificateName $CertificateName -CertificateVersion $CertificateVersion -RevocationReason $RevocationReason -JobId $jobId
         }
         catch {
             Write-CertLCLogAndThrow -Section 'Dispatcher.Revocation' -Message 'Error processing certificate revocation request' -Inner $_.Exception -NotifyTo $NotifyTo
         }
 
+        # If the revoked version was the latest version of the certificate, warn the operator:
+        # any consumer that requests this certificate without specifying a version will receive
+        # a "disabled" error from Key Vault until either a new version is created (e.g. via the
+        # renewal flow) or the version is manually re-enabled. Auto-renewal via the near-expiry
+        # event is suppressed for revoked versions (see DISPATCHER.RENEWAL).
+        if ($IsLatestVersion) {
+            Write-CertLCLog -Section 'Dispatcher.Revocation' -Level 'Warning' -Message "The revoked version $CertificateVersion is the LATEST version of certificate $CertificateName in vault $VaultName. Consumers requesting this certificate without specifying a version will now receive an error from Key Vault until a new version is created."
+        }
+
         # send notification email if requested and SMTP is configured
         if ($NotifyTo -and -not [string]::IsNullOrEmpty($SmtpServer)) {
-            $subject = "Certificate $CertificateName revoked successfully"
-            $fragment = [System.Net.WebUtility]::HtmlEncode("The certificate $CertificateName has been successfully revoked in CA and deleted from the Key Vault $VaultName.")
+            $subject = "Certificate $CertificateName version revoked successfully"
+            $fragmentText = "The version $CertificateVersion of certificate $CertificateName has been revoked at the CA and disabled in Key Vault $VaultName. The certificate object remains in the vault for audit purposes; other versions (if any) are unaffected."
+            $fragment = [System.Net.WebUtility]::HtmlEncode($fragmentText)
             $body = $CertificateNotificationEmailBodyHtml -replace '__CONTENT__', $fragment
             Send-NotificationEmail -SmtpServer $SmtpServer -FromAddress $fromAddress -To $NotifyTo -Subject $subject -Body $body -smtpCredential $SmtpCredential
         }
@@ -1961,7 +2111,7 @@ switch ($requestBody.type) {
         }
 
         # confirm revocation
-        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Certificate $CertificateName was successfully revoked."
+        Write-CertLCLog -Section 'Dispatcher.Revocation' -Message "Certificate $CertificateName version $CertificateVersion was successfully revoked (CA: serial revoked; KeyVault: version disabled and tagged)."
     }
 
     #endregion

--- a/Runbooks/certlc.ps1
+++ b/Runbooks/certlc.ps1
@@ -522,6 +522,112 @@ function Write-CertLCLogAndThrow {
 
 #endregion
 
+#region ### Invoke-WithRetry ###
+
+##############################
+# FUNCTIONS - Invoke-WithRetry #
+##############################
+
+<#
+.SYNOPSIS
+    Execute a script block with retries on transient failures (HTTP 408/429/5xx and common
+    network / AD / COM exceptions). Intended for IDEMPOTENT operations only (GET REST calls,
+    AD reads, etc.). NEVER wrap a non-idempotent operation such as a certificate import,
+    a CertRequest.Submit, or an Update-AzKeyVaultCertificate -- a retry could double-apply.
+
+.PARAMETER ScriptBlock
+    The block to execute. Must be safe to re-run on transient failures (idempotent).
+    Pass it with .GetNewClosure() if it references variables from the caller's scope.
+
+.PARAMETER OperationName
+    Short label included in retry / failure log lines.
+
+.PARAMETER Section
+    Log section, propagated to Write-CertLCLog. Defaults to 'Invoke-WithRetry'.
+
+.PARAMETER MaxAttempts
+    Total attempts including the first one. Defaults to 4 (initial + 3 retries).
+
+.PARAMETER InitialDelayMs
+    Base delay (ms) before the first retry. Subsequent delays grow exponentially with jitter,
+    capped at 30 seconds. Defaults to 500.
+
+.NOTES
+    Retry-After response headers (sent by Key Vault and other Azure services on 429 / 503) are
+    honoured when present and take precedence over the computed backoff.
+#>
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock,
+        [Parameter(Mandatory)][string]$OperationName,
+        [Parameter()][string]$Section = 'Invoke-WithRetry',
+        [Parameter()][int]$MaxAttempts = 4,
+        [Parameter()][int]$InitialDelayMs = 500
+    )
+
+    # HTTP status codes considered transient.
+    $retryableHttp = @(408, 429, 500, 502, 503, 504)
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            return & $ScriptBlock
+        }
+        catch {
+            $err = $_
+            $ex  = $err.Exception
+            $isLastAttempt = ($attempt -ge $MaxAttempts)
+
+            # Try to read an HTTP status code if this is an Invoke-RestMethod / Invoke-WebRequest failure.
+            $statusCode  = $null
+            $retryAfterMs = $null
+            $respProp = $ex.PSObject.Properties['Response']
+            if ($null -ne $respProp -and $null -ne $respProp.Value) {
+                try { $statusCode = [int]$respProp.Value.StatusCode } catch { $statusCode = $null }
+                try {
+                    $ra = $respProp.Value.Headers.RetryAfter
+                    if ($null -ne $ra -and $null -ne $ra.Delta) {
+                        $retryAfterMs = [int]$ra.Delta.TotalMilliseconds
+                    }
+                }
+                catch { $retryAfterMs = $null }
+            }
+
+            # Decide whether this exception is worth retrying.
+            $shouldRetry = $false
+            if ($null -ne $statusCode -and $retryableHttp -contains $statusCode) {
+                $shouldRetry = $true
+            }
+            elseif ($ex -is [System.Net.Http.HttpRequestException] -or
+                    $ex -is [System.TimeoutException] -or
+                    $ex -is [System.IO.IOException] -or
+                    $ex -is [System.Net.WebException] -or
+                    $ex -is [System.Runtime.InteropServices.COMException]) {
+                $shouldRetry = $true
+            }
+
+            if (-not $shouldRetry -or $isLastAttempt) {
+                throw
+            }
+
+            # Backoff: Retry-After if present, otherwise exponential with jitter capped at 30s.
+            if ($null -ne $retryAfterMs -and $retryAfterMs -gt 0) {
+                $delayMs = [Math]::Min($retryAfterMs, 30000)
+            }
+            else {
+                $delayMs = [Math]::Min(30000, $InitialDelayMs * [Math]::Pow(2, $attempt - 1))
+                $delayMs += (Get-Random -Minimum 0 -Maximum $InitialDelayMs)
+            }
+
+            $statusInfo = if ($null -ne $statusCode) { "HTTP $statusCode" } else { $ex.GetType().Name }
+            Write-CertLCLog -Section $Section -Level 'Warning' -Message "[$OperationName] Attempt $attempt of $($MaxAttempts) failed ($statusInfo): $($ex.Message). Retrying after $([int]$delayMs)ms..."
+            Start-Sleep -Milliseconds ([int]$delayMs)
+        }
+    }
+}
+
+#endregion
+
 #region ### Format-PfxProtectTo ###
 
 ####################################
@@ -901,7 +1007,9 @@ function Find-TemplateName {
         -replace "`0",  '\00'
     $searcher.Filter = "(&(objectClass=pKICertificateTemplate)(|(cn=$escaped)(displayName=$escaped)(msPKI-Cert-Template-OID=$escaped)))"
     $searcher.PropertiesToLoad.Add('name') | Out-Null
-    $result = $searcher.FindOne()
+    # AD reads are idempotent; retry transient DC unavailability (COMException etc.).
+    $findOne = { $searcher.FindOne() }.GetNewClosure()
+    $result = Invoke-WithRetry -ScriptBlock $findOne -OperationName "AD template lookup '$cnOrDisplayNameOrOid'" -Section 'Find-TemplateName'
     if ($null -eq $result) {
         return [string]::Empty
     }
@@ -1307,8 +1415,14 @@ function Get-CertificateByThumbprint {
     $secureToken = $tokenResult.Token
     $invokeApi = {
         param([string]$uri)
-        # $secureToken is captured from the enclosing scope
-        return Invoke-RestMethod -Uri $uri -Method GET -Authentication Bearer -Token $secureToken -ContentType 'application/json'
+        # $secureToken lives in the enclosing function scope. GetNewClosure() only captures
+        # variables that are LOCAL to the script block where it is invoked, so we first pull
+        # the token into this scope before creating the closure.
+        $tok = $secureToken
+        $op = {
+            Invoke-RestMethod -Uri $uri -Method GET -Authentication Bearer -Token $tok -ContentType 'application/json'
+        }.GetNewClosure()
+        return Invoke-WithRetry -ScriptBlock $op -OperationName "KV GET $uri" -Section 'Get-CertificateByThumbprint'
     }
 
     $vaultBaseUrl = "https://$VaultName.vault.azure.net"

--- a/Setup/README.md
+++ b/Setup/README.md
@@ -252,6 +252,7 @@ The deployment requires the following parameters (configured in `parameters.dev.
 | `logAnalyticsWorkspaceName` | Name for the Log Analytics Workspace |
 | `applicationInsightsName` | Name for the Application Insights instance |
 | `automationAccountName` | Name for the Automation Account |
+| `runbookName` | Name of the primary runbook placeholder created on the Automation Account (default `certlc`). The actual `certlc.ps1` code is uploaded post-deployment |
 | `runtimeEnvironmentName` | Name of the custom PowerShell 7.6 runtime environment created on the Automation Account and used by both runbooks (default `certlc-PowerShell-7-6`; names cannot contain dots) |
 | `hybridWorkerGroupName` | Name for the Hybrid Worker Group |
 | `keyVaultName` | Name for the Key Vault |
@@ -314,7 +315,7 @@ The solution follows a secure-by-default architecture:
 - Role-based access control (RBAC) follows the principle of least privilege
 - Automation Account variables for sensitive data are encrypted
 - Key Vault uses RBAC authorization and soft delete protection
-- The runbook never deletes certificates from Key Vault: revocations are recorded by disabling the specific version and tagging it (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). Vault soft-delete / purge-protection settings still apply to operator actions performed outside the runbook
+- The runbook never deletes certificates from Key Vault: revocations are recorded by disabling the specific version and tagging it (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). Renewed versions are likewise tagged with `RenewedJobId` for traceability. A duplicate revocation against an already-revoked version is rejected up-front with an `ALREADY REVOKED` error and the previous audit tags are preserved. Vault soft-delete / purge-protection settings still apply to operator actions performed outside the runbook
 - Diagnostic settings enabled on critical resources (Automation Account, Key Vault) for audit logging
 
 ## RBAC Role Assignments

--- a/Setup/README.md
+++ b/Setup/README.md
@@ -314,6 +314,7 @@ The solution follows a secure-by-default architecture:
 - Role-based access control (RBAC) follows the principle of least privilege
 - Automation Account variables for sensitive data are encrypted
 - Key Vault uses RBAC authorization and soft delete protection
+- The runbook never deletes certificates from Key Vault: revocations are recorded by disabling the specific version and tagging it (`Revoked=true`, `RevokedAt`, `RevocationReason`, `RevokedJobId`). Vault soft-delete / purge-protection settings still apply to operator actions performed outside the runbook
 - Diagnostic settings enabled on critical resources (Automation Account, Key Vault) for audit logging
 
 ## RBAC Role Assignments


### PR DESCRIPTION
## Summary

Closes the queued code-review backlog on the `certlc.ps1` runbook and refreshes the READMEs so the documentation reflects the current implementation.

## Commits

| SHA | Scope | Change |
|---|---|---|
| `f7e1f75` | Security | **S2** — RFC 4515 LDAP escape in `Find-TemplateName` to prevent filter injection from caller-supplied template names |
| `16c01c3` | Cosmetic | **M1+M4+M6+M8** — `Set-AzContext -DefaultProfile`; named CA disposition constants (`$CR_DISP_*`); PascalCase parameter casing in `Send-NotificationEmail` / `Write-CertLCLogAndThrow`; `[pscredential]::new(...)` instead of `New-Object` |
| `8a21177` | Robustness | **R3** — tag renewed Key Vault versions with `RenewedJobId=<automation-job-id>` for traceability |
| `d28ca13` | Robustness | **R1** — `Invoke-WithRetry` helper with exponential backoff + jitter, honoring `Retry-After`; opt-in retries on idempotent KV / LDAP reads (HTTP 408/429/5xx + `HttpRequestException`/`WebException`/`TimeoutException`/`IOException`/`COMException`). Mutating calls are intentionally **not** retried |
| `6bcc6f6` | Robustness | Idempotency guard in `Dispatcher.Revocation`: when the matched version already carries `Revoked=true`, fail fast with an `ALREADY REVOKED` log line (including prior `RevokedAt`, `RevocationReason`, `RevokedJobId`) before calling `Get-AzKeyVaultSecret` / the CA. Original audit tags are preserved |
| `eb60ec2` | Docs | Refresh `README.md`, `Setup/README.md`, `LogAnalytics/customTable/README.md` to match the implementation (RenewedJobId tag, idempotency guard, retry behavior, missing `runbookName` Bicep parameter; customTable README rewritten as reference since the Bicep template now provisions everything automatically) |

## Validation

- `get_errors` clean on every commit.
- **R1 smoke test** against `flazkv-certlc-itn-001` / `cert001` (version `01b2bce6…`, thumbprint `D54054BA…0F61F7D`): patched `Get-CertificateByThumbprint` returned the expected version in 3.59 s.
- **Revocation-guard smoke test** against the same vault: simulated `Revoked=true` tag set, ran the dispatcher inline, asserted (a) guard threw with `ALREADY REVOKED`, (b) `Get-AzKeyVaultSecret` was never reached, (c) no misleading "Error getting certificate from key vault" line in the log. Original tags restored cleanly after the test.

## Items explicitly dismissed (no change)

S3, M2, M5, M7, C1 (full `Az.KeyVault` rewrite — dropped after live parity testing), C4, R2.